### PR TITLE
update Dockerfiles

### DIFF
--- a/docker/Dockerfile-centos-7
+++ b/docker/Dockerfile-centos-7
@@ -36,11 +36,11 @@ LABEL maintainer="AzureStack PowerShell Team <azsdevexp@microsoft.com>" \
 
 COPY scripts/* /
 
-RUN pwsh Install-AzureStackPowerShell.ps1 -REPOSITORY ${REPOSITORY} -AZURESTACK_PROFILE ${AZURESTACK_PROFILE} -AZURESTACK_VERSION ${AZURESTACK_VERSION}
+SHELL ["pwsh", "-Command"]
 
-RUN pwsh Install-AzureStackTools.ps1
-
-RUN pwsh -Command Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion ${READINESS_CHECKER_VERSION} -AllowPrerelease
+RUN ./Install-AzureStackPowerShell.ps1 -REPOSITORY $Env:REPOSITORY -AZURESTACK_PROFILE $Env:AZURESTACK_PROFILE -AZURESTACK_VERSION $Env:AZURESTACK_VERSION
+RUN ./Install-AzureStackTools.ps1
+RUN Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion $Env:READINESS_CHECKER_VERSION -AllowPrerelease -Force
 
 # create AzureRmContextSettings.json before it was generated
 COPY ${CONFIG}/${AZURERM_CONTEXT_SETTINGS} ${AZURE}/${AZURERM_CONTEXT_SETTINGS}

--- a/docker/Dockerfile-debian-9
+++ b/docker/Dockerfile-debian-9
@@ -36,14 +36,13 @@ LABEL maintainer="AzureStack PowerShell Team <azsdevexp@microsoft.com>" \
 
 COPY scripts/* /
 
-RUN pwsh Install-AzureStackPowerShell.ps1 -REPOSITORY ${REPOSITORY} -AZURESTACK_PROFILE ${AZURESTACK_PROFILE} -AZURESTACK_VERSION ${AZURESTACK_VERSION}
+SHELL ["pwsh", "-Command"]
 
-RUN pwsh Install-AzureStackTools.ps1
-
-RUN pwsh -Command Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion ${READINESS_CHECKER_VERSION} -AllowPrerelease
+RUN ./Install-AzureStackPowerShell.ps1 -REPOSITORY $Env:REPOSITORY -AZURESTACK_PROFILE $Env:AZURESTACK_PROFILE -AZURESTACK_VERSION $Env:AZURESTACK_VERSION
+RUN ./Install-AzureStackTools.ps1
+RUN Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion $Env:READINESS_CHECKER_VERSION -AllowPrerelease -Force
 
 # create AzureRmContextSettings.json before it was generated
 COPY ${CONFIG}/${AZURERM_CONTEXT_SETTINGS} ${AZURE}/${AZURERM_CONTEXT_SETTINGS}
 
 CMD [ "pwsh" ]
-

--- a/docker/Dockerfile-ubuntu-18.04
+++ b/docker/Dockerfile-ubuntu-18.04
@@ -36,11 +36,11 @@ LABEL maintainer="AzureStack PowerShell Team <azsdevexp@microsoft.com>" \
 
 COPY scripts/* /
 
-RUN pwsh Install-AzureStackPowerShell.ps1 -REPOSITORY ${REPOSITORY} -AZURESTACK_PROFILE ${AZURESTACK_PROFILE} -AZURESTACK_VERSION ${AZURESTACK_VERSION}
+SHELL ["pwsh", "-Command"]
 
-RUN pwsh Install-AzureStackTools.ps1
-
-RUN pwsh -Command Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion ${READINESS_CHECKER_VERSION} -AllowPrerelease
+RUN ./Install-AzureStackPowerShell.ps1 -REPOSITORY $Env:REPOSITORY -AZURESTACK_PROFILE $Env:AZURESTACK_PROFILE -AZURESTACK_VERSION $Env:AZURESTACK_VERSION
+RUN ./Install-AzureStackTools.ps1
+RUN Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion $Env:READINESS_CHECKER_VERSION -AllowPrerelease -Force
 
 # create AzureRmContextSettings.json before it was generated
 COPY ${CONFIG}/${AZURERM_CONTEXT_SETTINGS} ${AZURE}/${AZURERM_CONTEXT_SETTINGS}


### PR DESCRIPTION
Currently the AZURESTACK_VERSION is 2.1.0, which is invalid and will cause an error when the docker files are built, but these dockerfiles are meant for use for the 2.1.0 release so it is left in.