### PR TITLE
Docker images for Github Actions Agent

### DIFF
--- a/docker/githubactions/Dockerfile-gha-centos-7
+++ b/docker/githubactions/Dockerfile-gha-centos-7
@@ -1,0 +1,57 @@
+FROM mcr.microsoft.com/powershell:centos-7
+
+ARG REPOSITORY=PSGallery
+ARG MODULE=Az
+ARG CONFIG=../config
+ARG AZURERM_CONTEXT_SETTINGS=AzureRmContextSettings.json
+ARG AZURE=/root/.Azure
+ARG VCS_REF="none"
+ARG BUILD_DATE=
+ARG VERSION=0.10.0
+ARG IMAGE_NAME=mcr.microsoft.com/azure-stack-powershell:${VERSION}-centos-7
+ARG AZURESTACK_PROFILE=2019-03-01-hybrid
+ARG AZURESTACK_VERSION=2.1.0
+ARG READINESS_CHECKER_VERSION=1.2005.1269-preview
+
+ENV AZUREPS_HOST_ENVIRONMENT="dockerImage/${VERSION}-centos-7"
+
+LABEL maintainer="AzureStack PowerShell Team <azsdevexp@microsoft.com>" \
+      readme.md="http://aka.ms/azspsdockerreadme" \
+      description="This Dockerfile will install the latest supported version of Azure PowerShell that works with AzureStack Hub." \
+      org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.usage="http://aka.ms/azspsdocker" \
+      org.label-schema.url="http://aka.ms/azspsdockerreadme" \
+      org.label-schema.vcs-url="https://github.com/Azure/azure-powershell" \
+      org.label-schema.name="azure powershell" \
+      org.label-schema.vendor="AzureStack PowerShell" \
+      org.label-schema.version=${VERSION} \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
+      org.label-schema.docker.cmd="docker run --rm ${IMAGE_NAME} pwsh -c '\$PSVERSIONTABLE'" \
+      org.label-schema.docker.cmd.devel="docker run -it --rm -e 'DebugPreference=Continue' ${IMAGE_NAME} pwsh" \
+      org.label-schema.docker.cmd.test="currently not available" \
+      org.label-schema.docker.cmd.help="docker run --rm ${IMAGE_NAME} pwsh -c Get-Help"
+
+# install azure-powershell and azure stack admin modules from PSGallery
+
+COPY ../scripts/* /scripts/
+
+SHELL ["pwsh", "-Command"]
+
+RUN ./scripts/Install-AzureStackPowerShell.ps1 -REPOSITORY $Env:REPOSITORY -AZURESTACK_PROFILE $Env:AZURESTACK_PROFILE -AZURESTACK_VERSION $Env:AZURESTACK_VERSION
+
+RUN Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion $Env:READINESS_CHECKER_VERSION -AllowPrerelease -Force
+
+# create AzureRmContextSettings.json before it was generated
+COPY ${CONFIG}/${AZURERM_CONTEXT_SETTINGS} ${AZURE}/${AZURERM_CONTEXT_SETTINGS}
+
+# install az cli
+RUN ./scripts/Install-AzCLICentOS.ps1
+
+# download actions agent
+RUN ./scripts/Download-ActionsAgent.ps1
+
+# clean scripts
+RUN rm -rf scripts
+
+CMD [ "pwsh" ]

--- a/docker/githubactions/Dockerfile-gha-debian-9
+++ b/docker/githubactions/Dockerfile-gha-debian-9
@@ -1,0 +1,57 @@
+FROM mcr.microsoft.com/powershell:debian-9
+
+ARG REPOSITORY=PSGallery
+ARG MODULE=Az
+ARG CONFIG=../config
+ARG AZURERM_CONTEXT_SETTINGS=AzureRmContextSettings.json
+ARG AZURE=/root/.Azure
+ARG VCS_REF="none"
+ARG BUILD_DATE=
+ARG VERSION=0.10.0
+ARG IMAGE_NAME=mcr.microsoft.com/azure-stack-powershell:${VERSION}-debian-9
+ARG AZURESTACK_PROFILE=2019-03-01-hybrid
+ARG AZURESTACK_VERSION=2.1.0
+ARG READINESS_CHECKER_VERSION=1.2005.1269-preview
+
+ENV AZUREPS_HOST_ENVIRONMENT="dockerImage/${VERSION}-debian-9"
+
+LABEL maintainer="AzureStack PowerShell Team <azsdevexp@microsoft.com>" \
+      readme.md="http://aka.ms/azspsdockerreadme" \
+      description="This Dockerfile will install the latest supported version of Azure PowerShell that works with AzureStack Hub." \
+      org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.usage="http://aka.ms/azspsdocker" \
+      org.label-schema.url="http://aka.ms/azspsdockerreadme" \
+      org.label-schema.vcs-url="https://github.com/Azure/azure-powershell" \
+      org.label-schema.name="azure powershell" \
+      org.label-schema.vendor="AzureStack PowerShell" \
+      org.label-schema.version=${VERSION} \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
+      org.label-schema.docker.cmd="docker run --rm ${IMAGE_NAME} pwsh -c '\$PSVERSIONTABLE'" \
+      org.label-schema.docker.cmd.devel="docker run -it --rm -e 'DebugPreference=Continue' ${IMAGE_NAME} pwsh" \
+      org.label-schema.docker.cmd.test="currently not available" \
+      org.label-schema.docker.cmd.help="docker run --rm ${IMAGE_NAME} pwsh -c Get-Help"
+
+# install azure-powershell and azure stack admin modules from PSGallery
+
+COPY scripts/* /scripts/
+
+SHELL ["pwsh", "-Command"]
+
+RUN ./scripts/Install-AzureStackPowerShell.ps1 -REPOSITORY $Env:REPOSITORY -AZURESTACK_PROFILE $Env:AZURESTACK_PROFILE -AZURESTACK_VERSION $Env:AZURESTACK_VERSION
+
+RUN Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion $Env:READINESS_CHECKER_VERSION -AllowPrerelease -Force
+
+# create AzureRmContextSettings.json before it was generated
+COPY ${CONFIG}/${AZURERM_CONTEXT_SETTINGS} ${AZURE}/${AZURERM_CONTEXT_SETTINGS}
+
+# install az cli
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# download actions agent
+RUN ./scripts/Download-ActionsAgent.ps1
+
+# clean scripts
+RUN rm -rf scripts
+
+CMD [ "pwsh" ]

--- a/docker/githubactions/Dockerfile-gha-ubuntu-18.04
+++ b/docker/githubactions/Dockerfile-gha-ubuntu-18.04
@@ -1,0 +1,57 @@
+FROM mcr.microsoft.com/powershell:ubuntu-18.04
+
+ARG REPOSITORY=PSGallery
+ARG MODULE=Az
+ARG CONFIG=../config
+ARG AZURERM_CONTEXT_SETTINGS=AzureRmContextSettings.json
+ARG AZURE=/root/.Azure
+ARG VCS_REF="none"
+ARG BUILD_DATE=
+ARG VERSION=0.10.0
+ARG IMAGE_NAME=mcr.microsoft.com/azure-stack-powershell:${VERSION}-ubuntu-18.04
+ARG AZURESTACK_PROFILE=2019-03-01-hybrid
+ARG AZURESTACK_VERSION=2.1.0
+ARG READINESS_CHECKER_VERSION=1.2005.1269-preview
+
+ENV AZUREPS_HOST_ENVIRONMENT="dockerImage/${VERSION}-ubuntu-18.04"
+
+LABEL maintainer="AzureStack PowerShell Team <azsdevexp@microsoft.com>" \
+      readme.md="http://aka.ms/azspsdockerreadme" \
+      description="This Dockerfile will install the latest supported version of Azure PowerShell that works with AzureStack Hub." \
+      org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.usage="http://aka.ms/azspsdocker" \
+      org.label-schema.url="http://aka.ms/azspsdockerreadme" \
+      org.label-schema.vcs-url="https://github.com/Azure/azure-powershell" \
+      org.label-schema.name="azure powershell" \
+      org.label-schema.vendor="AzureStack PowerShell" \
+      org.label-schema.version=${VERSION} \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
+      org.label-schema.docker.cmd="docker run --rm ${IMAGE_NAME} pwsh -c '\$PSVERSIONTABLE'" \
+      org.label-schema.docker.cmd.devel="docker run -it --rm -e 'DebugPreference=Continue' ${IMAGE_NAME} pwsh" \
+      org.label-schema.docker.cmd.test="currently not available" \
+      org.label-schema.docker.cmd.help="docker run --rm ${IMAGE_NAME} pwsh -c Get-Help"
+
+# install azure-powershell and azure stack admin modules from PSGallery
+
+COPY scripts/* /scripts/
+
+SHELL ["pwsh", "-Command"]
+
+RUN ./scripts/Install-AzureStackPowerShell.ps1 -REPOSITORY $Env:REPOSITORY -AZURESTACK_PROFILE $Env:AZURESTACK_PROFILE -AZURESTACK_VERSION $Env:AZURESTACK_VERSION
+
+RUN Install-Module -Name Microsoft.AzureStack.ReadinessChecker -RequiredVersion $Env:READINESS_CHECKER_VERSION -AllowPrerelease -Force
+
+# create AzureRmContextSettings.json before it was generated
+COPY ${CONFIG}/${AZURERM_CONTEXT_SETTINGS} ${AZURE}/${AZURERM_CONTEXT_SETTINGS}
+
+# install az cli
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# download actions agent
+RUN ./scripts/Download-ActionsAgent.ps1
+
+# clean scripts
+RUN rm -rf scripts
+
+CMD [ "pwsh" ]

--- a/docker/githubactions/README.md
+++ b/docker/githubactions/README.md
@@ -1,0 +1,37 @@
+# Docker
+
+
+## Overview
+These Dockerfiles create containers suitable for running github actions agents against AzureStack
+
+## Configuration
+This image requires Docker 17.05 or newer.
+
+It is also expected that you are able to run Docker without `sudo`.
+Please follow [Docker's official instructions][install] to install `docker` correctly.
+[install]: https://docs.docker.com/engine/installation/
+
+
+## Release
+The release containers derive from the [Powershell image][powershell image], and then install the current Az package.
+[powershell image]: https://hub.docker.com/_/microsoft-powershell
+
+## Build
+```
+# go one directory up and run the below cmd from docker folder
+docker build -f .\githubactions\Dockerfile-gha-ubuntu-18.04 --build-arg VERSION=0.2002.0 --build-arg AZURESTACK_VERSION=2.0.2-preview .
+```
+
+## Configuring github actions agent in AzureStack
+```
+# create a vm, add DockerExtension
+az vm create --resource-group "test" --name "testVM" --image "UbuntuLTS" --admin-username "demouser" --admin-password "demouser@111" --location "local"
+az vm extension set -n DockerExtension --publisher Microsoft.Azure.Extensions --vm-name testVM -g test
+# ssh to created vm and pull docker image
+docker pull mcr.microsoft.com/azurestack/powershell:<tag>
+docker run -it mcr.microsoft.com/azurestack/powershell:0.1.0-ubuntu-18.04
+# configure github actions agent (get token from the github repo settings)
+cd ./root/actions-runner
+./config.cmd --url https://github.com/azure/azurestack-powershell --token <REDACTED>
+./run.sh
+```

--- a/docker/scripts/Download-ActionsAgent.ps1
+++ b/docker/scripts/Download-ActionsAgent.ps1
@@ -1,0 +1,8 @@
+# Change directory to the home directory.
+Set-Location
+# Create a folder
+mkdir actions-runner && cd actions-runner
+# Download the latest runner package
+curl -O -L https://github.com/actions/runner/releases/download/v2.276.0/actions-runner-linux-x64-2.276.0.tar.gz
+# Extract the installer
+tar xzf ./actions-runner-linux-x64-2.276.0.tar.gz

--- a/docker/scripts/Install-AzCLICentOS.ps1
+++ b/docker/scripts/Install-AzCLICentOS.ps1
@@ -1,0 +1,11 @@
+# Import the Microsoft repository key
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+# Create local azure-cli repository information
+echo "[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc" | tee /etc/yum.repos.d/azure-cli.repo
+# Install with the yum install command
+yum -y install azure-cli


### PR DESCRIPTION
changing target branch to dev, previous PR -- https://github.com/Azure/azurestack-powershell/pull/67

Updating docker images so that it can be used for running Github Actions agents.

User will create a vm, add DockerExtension and then can configure agent runner within the container 

```
az vm create --resource-group "test" --name "testVM" --image "UbuntuLTS" --admin-username "demouser" --admin-password "demouser@111" --location "local"
az vm extension set -n DockerExtension --publisher Microsoft.Azure.Extensions --vm-name testVM -g test
```