### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           }
 
           $modulesToRun = Convert-FromArrayToJsonArrayString -ArrayOfStrings $modulesToRun
-          echo "::set-output name=MODULES_TO_RUN::${modulesToRun}"
+          echo "MODULES_TO_RUN=${modulesToRun}" >> $GITHUB_OUTPUT
 
     outputs:
       MODULES_TO_RUN: ${{ steps.resolve_modules_to_run.outputs.MODULES_TO_RUN }}
@@ -167,7 +167,7 @@ jobs:
             throw "Error while running pack-module.ps1."
           }
 
-          echo "::set-output name=MODULE_PATH::${modulePath}"
+          echo "MODULE_PATH=${modulePath}" >> $GITHUB_OUTPUT
           Pop-Location
           Write-Host "Ending autorest tests."
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`